### PR TITLE
Fix exporting methods with 'PackedByteArray' and 'PackedStringArray' as parameters

### DIFF
--- a/src/godot/macros/ArgumentMacros.hx
+++ b/src/godot/macros/ArgumentMacros.hx
@@ -98,6 +98,39 @@ class ArgumentMacros {
                             );
                             v;
                         };
+
+                    case 'PackedByteArray':
+                        macro {
+                            var p = new PackedByteArray();
+
+                            (untyped __cpp__(
+                                'memcpy({4}->opaque, (uint8_t *)(*((({0} **){1})+{2})+{3}), {5})',
+                                $i{ptrSize},
+                                $i{_args},
+                                $v{_index},
+                                $v{_offset},
+                                p,
+                            PackedByteArray.PACKEDBYTEARRAY_SIZE
+                            ));
+                            p;
+                        }
+
+                    case 'PackedStringArray':
+                        macro {
+                            var p = new PackedStringArray();
+
+                            (untyped __cpp__(
+                                'memcpy({4}->opaque, (uint8_t *)(*((({0} **){1})+{2})+{3}), {5})',
+                                $i{ptrSize},
+                                $i{_args},
+                                $v{_index},
+                                $v{_offset},
+                                p,
+                                PackedStringArray.PACKEDSTRINGARRAY_SIZE
+                            ));
+                            p;
+                        }
+
                     default: {
                         var identBindings = '&::godot::${_d.name}_obj::___binding_callbacks';
                         macro {


### PR DESCRIPTION
Fixes #22. Looks like this works well with the example project, but the game will crash if you try to read a value of any array using the `trace` function.